### PR TITLE
Dev

### DIFF
--- a/flacsync/__init__.py
+++ b/flacsync/__init__.py
@@ -476,7 +476,7 @@ def get_opts( argv ):
    helpstr = """
       set the AAC encoder quality value, must be a float range of 0..1
       [default:%default]"""
-   aac_group.add_option( '-q', '--aac-quality', dest='aac_q', default='0.35',
+   aac_group.add_option( '-q', '--aac-quality', dest='aac_q', default='0.5',
          action='callback', callback=store_enc_opt, callback_args=('aac',),
          type='string', help=_help_str(helpstr) )
    parser.add_option_group( aac_group )

--- a/flacsync/__init__.py
+++ b/flacsync/__init__.py
@@ -201,7 +201,7 @@ class WorkUnit( object ):
          sys.stdout.flush()
          if encoder.encode( self._opts.force ):
             encoder.tag( decoder.FlacDecoder(file_).tags )
-            encoder.set_cover(True)  # force new cover
+            encoder.set_cover(True, self._opts.art_resize)  # force new cover
          else: # update cover if newer
             encoder.set_cover()
       except KeyboardInterrupt:
@@ -464,6 +464,12 @@ def get_opts( argv ):
       parent directory of BASE_DIR. See BASE_DIR above."""
    parser.add_option( '-d', '--destination', dest='dest_dir',
          help=_help_str(helpstr) )
+   
+   helpstr = """
+      enable resizing of cover art; by default the art that is found will be
+      saved to file without resizing."""
+   parser.add_option( '-r', '--resize', dest='art_resize', default=False,
+         action="store_true", help=_help_str(helpstr) )
 
    # AAC only options
    aac_group = op.OptionGroup( parser, "AAC Encoder Options" )
@@ -563,4 +569,3 @@ def main( argv=None ):
       queue.join()
    except KeyboardInterrupt:
       work_obj.abort = True
-

--- a/flacsync/__init__.py
+++ b/flacsync/__init__.py
@@ -203,7 +203,7 @@ class WorkUnit( object ):
             encoder.tag( decoder.FlacDecoder(file_).tags )
             encoder.set_cover(True, self._opts.art_resize)  # force new cover
          else: # update cover if newer
-            encoder.set_cover()
+            encoder.set_cover(False, self._opts.art_resize)
       except KeyboardInterrupt:
          self.abort = True
       except Exception as exc:

--- a/flacsync/__init__.py
+++ b/flacsync/__init__.py
@@ -144,6 +144,7 @@ DEFAULT_ENCODER = 'aac'
 # define a mapping of enocoder-types to implementation class name.
 ENCODERS = {'aac':encoder.AacEncoder,
             'ogg':encoder.OggEncoder,
+            'mp3':encoder.MP3Encoder,
          }
 CORES = mp.cpu_count()
 
@@ -481,8 +482,18 @@ def get_opts( argv ):
       [default:%default]"""
    ogg_group.add_option( '-g', '--ogg-quality', dest='ogg_q', default='5',
          action='callback', callback=store_enc_opt, callback_args=('ogg',),
-        type='string', help=_help_str(helpstr) )
+         type='string', help=_help_str(helpstr) )
    parser.add_option_group( ogg_group )
+
+   # MP3 only options
+   mp3_group = op.OptionGroup( parser, "MP3 Encoder Options" )
+   helpstr = """
+      set the Lame MP3 encoder quality value, must be a initeger range of 9..0
+      [default:%default]"""
+   mp3_group.add_option( '-m', '--mp3-quality', dest='mp3_q', default='3',
+         action='callback', callback=store_enc_opt, callback_args=('mp3',),
+         type='string', help=_help_str(helpstr) )
+   parser.add_option_group( mp3_group )
 
    # examine input args
    (opts, args) = parser.parse_args( argv )

--- a/flacsync/__init__.py
+++ b/flacsync/__init__.py
@@ -144,7 +144,7 @@ DEFAULT_ENCODER = 'aac'
 # define a mapping of enocoder-types to implementation class name.
 ENCODERS = {'aac':encoder.AacEncoder,
             'ogg':encoder.OggEncoder,
-            'mp3':encoder.MP3Encoder,
+            'mp3':encoder.Mp3Encoder,
          }
 CORES = mp.cpu_count()
 

--- a/flacsync/encoder.py
+++ b/flacsync/encoder.py
@@ -182,8 +182,8 @@ class AacEncoder( _Encoder ):
       :type  force:  boolean
       """
       if self.cover and (force or util.newer(self.cover,self.dst)):
-		 if self.cover_dst and not os.path.isfile(self.cover_dst):
-		    shutil.copyfile(self.cover, self.cover_dst)
+         if self.cover_dst and not os.path.isfile(self.cover_dst):
+            shutil.copyfile(self.cover, self.cover_dst)
          tmp_cover = self._cover_thumbnail(resize)
          err = sp.call( 'neroAacTag "%s" -remove-cover:all -add-cover:front:"%s"' %
                   (self.dst, tmp_cover.name,), shell=True, stderr=NULL)
@@ -269,8 +269,8 @@ class OggEncoder( _Encoder ):
       mime = 'image/jpeg'
       description = "album cover"
       if self.cover and (force or util.newer(self.cover,self.dst)):
-		 if self.cover_dst and not os.path.isfile(self.cover_dst):
-		    shutil.copyfile(self.cover, self.cover_dst)
+	 if self.cover_dst and not os.path.isfile(self.cover_dst):
+	    shutil.copyfile(self.cover, self.cover_dst)
          tmp_cover = self._cover_thumbnail(resize)
          bin_cover = tmp_cover.read()
          meta_block = struct.pack(

--- a/flacsync/encoder.py
+++ b/flacsync/encoder.py
@@ -269,8 +269,8 @@ class OggEncoder( _Encoder ):
       mime = 'image/jpeg'
       description = "album cover"
       if self.cover and (force or util.newer(self.cover,self.dst)):
-	 if self.cover_dst and not os.path.isfile(self.cover_dst):
-	    shutil.copyfile(self.cover, self.cover_dst)
+         if self.cover_dst and not os.path.isfile(self.cover_dst):
+            shutil.copyfile(self.cover, self.cover_dst)
          tmp_cover = self._cover_thumbnail(resize)
          bin_cover = tmp_cover.read()
          meta_block = struct.pack(

--- a/flacsync/encoder.py
+++ b/flacsync/encoder.py
@@ -28,7 +28,7 @@ NULL = file('/dev/null')
 #: List of album covers, in preferential order.
 COVERS = ['cover.jpg', 'folder.jpg', 'front.jpg', 'album.jpg']
 #: Resolution of re-sized album covers.
-THUMBSIZE = 250,250
+THUMBSIZE = 500,500
 
 
 #############################################################################
@@ -329,7 +329,7 @@ class Mp3Encoder( _Encoder ):
          tmp_cover = self._cover_thumbnail()
          imagedata = open(tmp_cover.name, 'rb').read()
          audio = MP3(self.dst)
-         audio.tags.add(APIC(encoding=3, mime="image/jpeg", type=3, desc="Front Cover", data=imagedata))
+         audio.tags.add(APIC(encoding=3, mime="image/jpeg", type=3, desc=u'Front Cover', data=imagedata))
          err = audio.save()
      return self._check_err( err, "MP3 add-cover failed:" )
 


### PR DESCRIPTION
These are probably ugly hacks but they work...

9f85376 fixes a small typo in the encoder list.
da323950 and 2560c61f change the cover art thumbnail generation behavior.  All my cover art is already sized so I really just want it to embed the art without resizing.
c5c842e9 copies the cover art into the destination folder structure.  This is for players that do not support embedded cover art.
